### PR TITLE
Enable Key Rotation by default

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "description" {
 
 variable "enable_key_rotation" {
   type        = bool
-  default     = false
+  default     = true
   description = "Specifies whether key rotation is enabled"
 }
 


### PR DESCRIPTION
This PR changes the default value for Key Rotation.

Key rotation is suggested by Security hub: https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#cis-2.8-remediation

Reading through the documentation enabling this has no impact on the usage of the keys, so it's harmless to enable. Therefore enable it by default.

```
AWS KMS retains all backing keys for a CMK, even if key rotation is disabled. The backing keys are deleted only when the CMK is deleted. When you use a CMK to encrypt, AWS KMS uses the current backing key. When you use the CMK to decrypt, AWS KMS uses the backing key that was used to encrypt.
```

**Documentation:**
- https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html
- https://docs.aws.amazon.com/kms/latest/cryptographic-details/rotate-customer-master-key.html
