### PR TITLE
bug: set default value of var.policy to null

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
 # terraform-aws-mcaf-kms
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_kms_alias.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
+| [aws_kms_key.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name"></a> [name](#input\_name) | The name of the key | `string` | n/a | yes |
+| <a name="input_deletion_window_in_days"></a> [deletion\_window\_in\_days](#input\_deletion\_window\_in\_days) | Delay in days after which the key is deleted | `number` | `30` | no |
+| <a name="input_description"></a> [description](#input\_description) | The description of the key as viewed in AWS console | `string` | `null` | no |
+| <a name="input_enable_key_rotation"></a> [enable\_key\_rotation](#input\_enable\_key\_rotation) | Specifies whether key rotation is enabled | `bool` | `true` | no |
+| <a name="input_policy"></a> [policy](#input\_policy) | A valid KMS policy JSON document | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the key | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_arn"></a> [arn](#output\_arn) | ARN of the key |
+| <a name="output_id"></a> [id](#output\_id) | ID of the key |
+<!-- END_TF_DOCS -->

--- a/variables.tf
+++ b/variables.tf
@@ -23,7 +23,7 @@ variable "name" {
 
 variable "policy" {
   type        = string
-  default     = ""
+  default     = null
   description = "A valid KMS policy JSON document"
 }
 


### PR DESCRIPTION
This pull request makes a small update to the default value for the `policy` variable in the `variables.tf` file. The change sets the default to `null` instead of an empty string, which is a more idiomatic way to indicate the absence of a value in Terraform.