### PR TITLE
feat: add missing variables of aws_kms_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
@@ -30,12 +30,17 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_name"></a> [name](#input\_name) | The name of the key | `string` | n/a | yes |
+| <a name="input_custom_key_store_id"></a> [custom\_key\_store\_id](#input\_custom\_key\_store\_id) | ID of the KMS Custom Key Store where the key will be stored instead of KMS (eg CloudHSM) | `string` | `null` | no |
+| <a name="input_customer_master_key_spec"></a> [customer\_master\_key\_spec](#input\_customer\_master\_key\_spec) | Specifies whether the key contains a symmetric key or an asymmetric key pair and the encryption algorithms or signing algorithms that the key supports. | `string` | `"SYMMETRIC_DEFAULT"` | no |
 | <a name="input_deletion_window_in_days"></a> [deletion\_window\_in\_days](#input\_deletion\_window\_in\_days) | Delay in days after which the key is deleted | `number` | `30` | no |
 | <a name="input_description"></a> [description](#input\_description) | The description of the key as viewed in AWS console | `string` | `null` | no |
 | <a name="input_enable_key_rotation"></a> [enable\_key\_rotation](#input\_enable\_key\_rotation) | Specifies whether key rotation is enabled | `bool` | `true` | no |
+| <a name="input_key_usage"></a> [key\_usage](#input\_key\_usage) | Specifies the intended use of the key. | `string` | `"ENCRYPT_DECRYPT"` | no |
+| <a name="input_multi_region"></a> [multi\_region](#input\_multi\_region) | Indicates whether the KMS key is a multi-Region (`true`) or regional (`false`) key. | `bool` | `false` | no |
 | <a name="input_policy"></a> [policy](#input\_policy) | A valid KMS policy JSON document | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | The AWS region where resources will be created; if omitted the default provider region is used | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the key | `map(string)` | `{}` | no |
+| <a name="input_xks_key_id"></a> [xks\_key\_id](#input\_xks\_key\_id) | Identifies the external key that serves as key material for the KMS key in an external key store | `string` | `null` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -5,11 +5,16 @@ resource "aws_kms_alias" "default" {
 }
 
 resource "aws_kms_key" "default" {
-  region                  = var.region
-  deletion_window_in_days = var.deletion_window_in_days
-  description             = coalesce(var.description, var.name)
-  enable_key_rotation     = var.enable_key_rotation
-  is_enabled              = true
-  policy                  = var.policy
-  tags                    = var.tags
+  region                   = var.region
+  custom_key_store_id      = var.custom_key_store_id
+  customer_master_key_spec = var.customer_master_key_spec
+  deletion_window_in_days  = var.deletion_window_in_days
+  description              = coalesce(var.description, var.name)
+  enable_key_rotation      = var.enable_key_rotation
+  is_enabled               = true
+  key_usage                = var.key_usage
+  multi_region             = var.multi_region
+  policy                   = var.policy
+  xks_key_id               = var.xks_key_id
+  tags                     = var.tags
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,9 +2,9 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.0"
     }
   }
 
-  required_version = ">= 1.4.0"
+  required_version = ">= 1.9.0"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,20 @@
+variable "custom_key_store_id" {
+  type        = string
+  default     = null
+  description = "ID of the KMS Custom Key Store where the key will be stored instead of KMS (eg CloudHSM)"
+}
+
+variable "customer_master_key_spec" {
+  type        = string
+  default     = "SYMMETRIC_DEFAULT"
+  description = "Specifies whether the key contains a symmetric key or an asymmetric key pair and the encryption algorithms or signing algorithms that the key supports."
+
+  validation {
+    condition     = contains(["SYMMETRIC_DEFAULT", "RSA_2048", "RSA_3072", "RSA_4096", "HMAC_256", "ECC_NIST_P256", "ECC_NIST_P384", "ECC_NIST_P521", "ECC_SECG_P256K1"], var.customer_master_key_spec)
+    error_message = "Allowed values for customer_master_key_spec are \"SYMMETRIC_DEFAULT\", \"RSA_2048\", \"RSA_3072\", \"RSA_4096\", \"HMAC_256\", \"ECC_NIST_P256\", \"ECC_NIST_P384\", \"ECC_NIST_P521\", \"ECC_SECG_P256K1\"."
+  }
+}
+
 variable "deletion_window_in_days" {
   type        = number
   default     = 30
@@ -14,6 +31,23 @@ variable "enable_key_rotation" {
   type        = bool
   default     = true
   description = "Specifies whether key rotation is enabled"
+}
+
+variable "key_usage" {
+  type        = string
+  default     = "ENCRYPT_DECRYPT"
+  description = "Specifies the intended use of the key."
+
+  validation {
+    condition     = contains(["ENCRYPT_DECRYPT", "SIGN_VERIFY", "GENERATE_VERIFY_MAC"], var.key_usage)
+    error_message = "Allowed values for key_usage are \"ENCRYPT_DECRYPT\", \"SIGN_VERIFY\", \"GENERATE_VERIFY_MAC\"."
+  }
+}
+
+variable "multi_region" {
+  type        = bool
+  default     = false
+  description = "Indicates whether the KMS key is a multi-Region (`true`) or regional (`false`) key."
 }
 
 variable "name" {
@@ -37,4 +71,15 @@ variable "tags" {
   type        = map(string)
   default     = {}
   description = "A mapping of tags to assign to the key"
+}
+
+variable "xks_key_id" {
+  type        = string
+  default     = null
+  description = "Identifies the external key that serves as key material for the KMS key in an external key store"
+
+  validation {
+    condition     = var.xks_key_id == null || var.custom_key_store_id != null
+    error_message = "xks_key_id can only be set when custom_key_store_id references an external key store."
+  }
 }


### PR DESCRIPTION
## :hammer_and_wrench: Summary

- Expose five new `aws_kms_key` arguments via module variables: `custom_key_store_id`, `customer_master_key_spec`, `key_usage`, `multi_region`, and `xks_key_id`.
- Set minimum terraform version to v1.9.0
