### PR TITLE
feat!: generate a secure least-privilege key policy by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,24 @@
 # terraform-aws-mcaf-kms
 
+Terraform module to manage an AWS KMS key and its alias.
+
+## Key policy
+
+By default the module generates a **least-privilege key policy** from the `default_policy` object.
+Grant access by listing principal ARNs in its`iam_arns_*` fields:
+
+* `iam_arns_administrator` for key management. If no administrator is given, the calling identity is added so the key is never left unmanageable.
+* `iam_arns_decrypt` / `iam_arns_decrypt_encrypt` for data operations.
+* `iam_arns_sign_verify` for signing.
+* `iam_arns_owner` for full access.
+
+> [!IMPORTANT]
+> Unlike AWS's default key policy, this policy does **not** grant the key to IAM principals just because their IAM policy allows `kms:*`.
+> Use and administration must be listed explicitly in `default_policy.iam_arns_*`.
+> (Read-only metadata access is still delegated to IAM while `iam_all_principals_read` is `true`.)
+
+To opt out, set `default_policy.enable` to `false` to use AWS's default key policy, or pass a complete document via `var.policy` (which always takes precedence).
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -24,6 +43,10 @@ No modules.
 |------|------|
 | [aws_kms_alias.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_session_context.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_session_context) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 
@@ -32,6 +55,7 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | The name of the key | `string` | n/a | yes |
 | <a name="input_custom_key_store_id"></a> [custom\_key\_store\_id](#input\_custom\_key\_store\_id) | ID of the KMS Custom Key Store where the key will be stored instead of KMS (eg CloudHSM) | `string` | `null` | no |
 | <a name="input_customer_master_key_spec"></a> [customer\_master\_key\_spec](#input\_customer\_master\_key\_spec) | Specifies whether the key contains a symmetric key or an asymmetric key pair and the encryption algorithms or signing algorithms that the key supports. | `string` | `"SYMMETRIC_DEFAULT"` | no |
+| <a name="input_default_policy"></a> [default\_policy](#input\_default\_policy) | Configuration object for defining the KMS key policy and permissions | <pre>object({<br/>    enable                    = optional(bool, true)<br/>    override_policy_documents = optional(list(string), [])<br/>    source_policy_documents   = optional(list(string), [])<br/><br/>    iam_all_principals_read  = optional(bool, true)<br/>    iam_arns_administrator   = optional(list(string), [])<br/>    iam_arns_decrypt         = optional(list(string), [])<br/>    iam_arns_decrypt_encrypt = optional(list(string), [])<br/>    iam_arns_owner           = optional(list(string), [])<br/>    iam_arns_sign_verify     = optional(list(string), [])<br/>    iam_aws_config_read      = optional(bool, true)<br/>  })</pre> | `{}` | no |
 | <a name="input_deletion_window_in_days"></a> [deletion\_window\_in\_days](#input\_deletion\_window\_in\_days) | Delay in days after which the key is deleted | `number` | `30` | no |
 | <a name="input_description"></a> [description](#input\_description) | The description of the key as viewed in AWS console | `string` | `null` | no |
 | <a name="input_enable_key_rotation"></a> [enable\_key\_rotation](#input\_enable\_key\_rotation) | Specifies whether key rotation is enabled | `bool` | `true` | no |
@@ -48,4 +72,5 @@ No modules.
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | ARN of the key |
 | <a name="output_id"></a> [id](#output\_id) | ID of the key |
+| <a name="output_policy"></a> [policy](#output\_policy) | The key policy applied to the key, as a JSON-encoded string |
 <!-- END_TF_DOCS -->

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,30 @@
 
 This document captures required refactoring on your part when upgrading to a module version that contains breaking changes.
 
+## Upgrading to v2.0.0
+
+### Key Changes
+
+- The module now generates a **least-privilege key policy by default**. When `default_policy.enable` is `true` (the new default) and no explicit `policy` is provided, the module builds the key policy from the new `default_policy` object instead of letting AWS apply its built-in default key policy.
+- **This changes how access to the key is granted.** AWS's default key policy delegates full control to IAM via an unconditional `arn:aws:iam::<account>:root` principal, meaning any IAM principal with the right IAM permissions can use the key. The generated policy instead constrains the root-account statement with `aws:PrincipalType = "Account"` (break-glass for the account root user only) and grants encryption/decryption, signing and administration **explicitly** through the `default_policy.iam_arns_*` fields. After upgrading, IAM-policy-based access that previously worked implicitly will stop working unless the principals are listed explicitly. Read-only metadata access remains delegated to IAM for all account principals while `iam_all_principals_read` is `true`.
+- If `default_policy.iam_arns_administrator` is empty, the calling identity (`aws_iam_session_context.issuer_arn`) is added as administrator so the key is never left without a manageable principal.
+
+### Required actions
+
+**This release is backwards compatible if you already pass `var.policy`**: it still takes precedence over the generated policy, so the resulting key policy is unchanged.
+Note: the module now always reads the `aws_caller_identity`, `aws_partition` and `aws_iam_session_context` data sources,
+so the principal running Terraform needs `sts:GetCallerIdentity` and (for assumed-role sessions) `iam:GetRole`/`iam:GetUser`.
+If you relied on AWS's default key policy (no `policy` set) and want to **keep that behaviour**, set `default_policy = { enable = false }`.
+
+To **adopt the new model**, set `var.policy` to `null` and grant access using `var.default_policy`, for example:
+
+```hcl
+default_policy = {
+  iam_arns_administrator   = ["arn:aws:iam::123456789012:role/key-admins"]
+  iam_arns_decrypt_encrypt = ["arn:aws:iam::123456789012:role/app"]
+}
+```
+
 ## Upgrading to v1.0.0
 
 ### Key Changes

--- a/examples/basic/terraform.tf
+++ b/examples/basic/terraform.tf
@@ -2,9 +2,9 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.0"
     }
   }
 
-  required_version = ">= 1.4.0"
+  required_version = ">= 1.9.0"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,21 @@
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+  partition  = data.aws_partition.current.partition
+  region     = var.region != null ? var.region : data.aws_region.current.region
+
+  # if no administrators are specified, include the current user to prevent key from getting unmanaged
+  iam_administrator = coalescelist(var.default_policy.iam_arns_administrator, [data.aws_iam_session_context.current.issuer_arn])
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_iam_session_context" "current" { arn = data.aws_caller_identity.current.arn }
+data "aws_partition" "current" {}
+data "aws_region" "current" {}
+
+################################################################################
+# Key
+################################################################################
+
 resource "aws_kms_alias" "default" {
   region        = var.region
   name          = "alias/${var.name}"
@@ -14,7 +32,202 @@ resource "aws_kms_key" "default" {
   is_enabled               = true
   key_usage                = var.key_usage
   multi_region             = var.multi_region
-  policy                   = var.policy
+  policy                   = var.default_policy.enable ? coalesce(var.policy, data.aws_iam_policy_document.kms_key_policy.json) : var.policy
   xks_key_id               = var.xks_key_id
   tags                     = var.tags
+}
+
+################################################################################
+# Policy
+################################################################################
+
+data "aws_iam_policy_document" "kms_key_policy" {
+  override_policy_documents = var.default_policy.override_policy_documents
+  source_policy_documents   = var.default_policy.source_policy_documents
+
+  # Allow root account full access to prevent key from getting unmanaged.
+  statement {
+    sid       = "AllowRootAccount"
+    actions   = ["kms:*"]
+    effect    = "Allow"
+    resources = ["arn:${local.partition}:kms:${local.region}:${local.account_id}:key/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalType"
+      values   = ["Account"]
+    }
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:${local.partition}:iam::${local.account_id}:root"
+      ]
+    }
+  }
+
+  # Allow all principals in the account read-only access. This is required to allow users to view the key in the AWS console.
+  dynamic "statement" {
+    for_each = var.default_policy.iam_all_principals_read ? [true] : []
+
+    content {
+      sid = "AllowAllPrincipalsRead"
+      actions = [
+        "kms:Describe*",
+        "kms:GetKeyPolicy",
+      ]
+      effect    = "Allow"
+      resources = ["*"]
+
+      principals {
+        type        = "AWS"
+        identifiers = ["arn:${local.partition}:iam::${local.account_id}:root"]
+      }
+    }
+  }
+
+  # Allow principals specified in iam_arns_administrator to have permissions to manage the KMS key, 
+  # but no permissions to use the KMS key in cryptographic operations. 
+  # https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#key-policy-default-allow-administrators
+  dynamic "statement" {
+    for_each = length(local.iam_administrator) > 0 ? [true] : []
+
+    content {
+      sid = "AllowAdministrator"
+      actions = [
+        "kms:CancelKeyDeletion",
+        "kms:Create*",
+        "kms:Delete*",
+        "kms:Describe*",
+        "kms:Disable*",
+        "kms:Enable*",
+        "kms:Get*",
+        "kms:ImportKeyMaterial",
+        "kms:List*",
+        "kms:Put*",
+        "kms:ReplicateKey",
+        "kms:Revoke*",
+        "kms:RotateKeyOnDemand",
+        "kms:ScheduleKeyDeletion",
+        "kms:TagResource",
+        "kms:UntagResource",
+        "kms:Update*"
+      ]
+      effect    = "Allow"
+      resources = ["*"]
+
+      principals {
+        type        = "AWS"
+        identifiers = var.default_policy.iam_arns_administrator
+      }
+    }
+  }
+
+  # Allow principals specified in iam_arns_decrypt to have permissions to use the KMS key for decryption operations, but not encryption operations.
+  dynamic "statement" {
+    for_each = length(var.default_policy.iam_arns_decrypt) > 0 ? [true] : []
+
+    content {
+      sid = "AllowDecrypt"
+      actions = [
+        "kms:Decrypt",
+        "kms:DescribeKey"
+      ]
+      effect    = "Allow"
+      resources = ["*"]
+
+      principals {
+        type        = "AWS"
+        identifiers = var.default_policy.iam_arns_decrypt
+      }
+    }
+  }
+
+  # Allow principals specified in iam_arns_decrypt_encrypt to have permissions to use the KMS key in cryptographic operations.
+  # https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#key-policy-default-allow-users
+  dynamic "statement" {
+    for_each = length(var.default_policy.iam_arns_decrypt_encrypt) > 0 ? [true] : []
+
+    content {
+      sid = "AllowDecryptEncrypt"
+      actions = concat(
+        [
+          "kms:Decrypt",
+          "kms:DescribeKey",
+          "kms:Encrypt",
+          "kms:ReEncrypt*",
+        ],
+        var.customer_master_key_spec == "SYMMETRIC_DEFAULT" ? ["kms:GenerateDataKey*"] : ["kms:GetPublicKey"]
+      )
+      effect    = "Allow"
+      resources = ["*"]
+
+      principals {
+        type        = "AWS"
+        identifiers = var.default_policy.iam_arns_decrypt_encrypt
+      }
+    }
+  }
+
+  # Allow principals specified in iam_arns_owner to have full access to the key. 
+  dynamic "statement" {
+    for_each = length(var.default_policy.iam_arns_owner) > 0 ? [true] : []
+
+    content {
+      sid       = "AllowOwner"
+      actions   = ["kms:*"]
+      effect    = "Allow"
+      resources = ["*"]
+
+      principals {
+        type        = "AWS"
+        identifiers = var.default_policy.iam_arns_owner
+      }
+    }
+  }
+
+  # Allow principals specified in iam_arns_sign_verify to have permissions to use the KMS key for signing and verification operations.
+  dynamic "statement" {
+    for_each = length(var.default_policy.iam_arns_sign_verify) > 0 ? [true] : []
+
+    content {
+      sid = "AllowSignVerify"
+      actions = [
+        "kms:DescribeKey",
+        "kms:GetPublicKey",
+        "kms:Sign",
+        "kms:Verify",
+      ]
+      effect    = "Allow"
+      resources = ["*"]
+
+      principals {
+        type        = "AWS"
+        identifiers = var.default_policy.iam_arns_sign_verify
+      }
+    }
+  }
+
+  # Allow AWS Config service read access to the key. This is required for AWS Config to be able to record configuration changes to the key and related events.
+  dynamic "statement" {
+    for_each = var.default_policy.iam_aws_config_read ? [true] : []
+
+    content {
+      sid = "AllowAwsConfigRead"
+      actions = [
+        "kms:Describe*",
+        "kms:GetKeyPolicy",
+        "kms:GetKeyRotationStatus"
+      ]
+      effect    = "Allow"
+      resources = ["*"]
+
+      principals {
+        type = "AWS"
+        identifiers = [
+          "arn:${local.partition}:iam::${local.account_id}:role/aws-service-role/config.amazonaws.com/AWSServiceRoleForConfig"
+        ]
+      }
+    }
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,16 +1,20 @@
 locals {
   account_id = data.aws_caller_identity.current.account_id
   partition  = data.aws_partition.current.partition
-  region     = var.region != null ? var.region : data.aws_region.current.region
 
-  # if no administrators are specified, include the current user to prevent key from getting unmanaged
+  # If no administrators are specified, fall back to the current caller so the key
+  # never ends up without a principal able to manage it.
   iam_administrator = coalescelist(var.default_policy.iam_arns_administrator, [data.aws_iam_session_context.current.issuer_arn])
+
+  # Use an explicit policy when provided, otherwise the generated default policy.
+  # When default_policy.enable is false and no explicit policy is set, the key is
+  # left unmanaged so AWS applies its built-in default key policy.
+  policy = var.default_policy.enable ? coalesce(var.policy, data.aws_iam_policy_document.kms_key_policy.json) : var.policy
 }
 
 data "aws_caller_identity" "current" {}
 data "aws_iam_session_context" "current" { arn = data.aws_caller_identity.current.arn }
 data "aws_partition" "current" {}
-data "aws_region" "current" {}
 
 ################################################################################
 # Key
@@ -32,7 +36,7 @@ resource "aws_kms_key" "default" {
   is_enabled               = true
   key_usage                = var.key_usage
   multi_region             = var.multi_region
-  policy                   = var.default_policy.enable ? coalesce(var.policy, data.aws_iam_policy_document.kms_key_policy.json) : var.policy
+  policy                   = local.policy
   xks_key_id               = var.xks_key_id
   tags                     = var.tags
 }
@@ -50,7 +54,7 @@ data "aws_iam_policy_document" "kms_key_policy" {
     sid       = "AllowRootAccount"
     actions   = ["kms:*"]
     effect    = "Allow"
-    resources = ["arn:${local.partition}:kms:${local.region}:${local.account_id}:key/*"]
+    resources = ["*"]
 
     condition {
       test     = "StringEquals"
@@ -118,7 +122,7 @@ data "aws_iam_policy_document" "kms_key_policy" {
 
       principals {
         type        = "AWS"
-        identifiers = var.default_policy.iam_arns_administrator
+        identifiers = local.iam_administrator
       }
     }
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,6 +9,6 @@ output "id" {
 }
 
 output "policy" {
-  value       = var.default_policy.enable ? coalesce(var.policy, data.aws_iam_policy_document.kms_key_policy.json) : var.policy
-  description = "Output for entire policy document"
+  value       = local.policy
+  description = "The key policy applied to the key, as a JSON-encoded string"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,8 @@ output "id" {
   value       = aws_kms_key.default.key_id
   description = "ID of the key"
 }
+
+output "policy" {
+  value       = var.default_policy.enable ? coalesce(var.policy, data.aws_iam_policy_document.kms_key_policy.json) : var.policy
+  description = "Output for entire policy document"
+}

--- a/tests/main.tftest.hcl
+++ b/tests/main.tftest.hcl
@@ -1,5 +1,16 @@
 # Mock aws provider, otherwise Terraform tries to connect to the service API.
-mock_provider "aws" {}
+# aws_caller_identity feeds aws_iam_session_context.arn, which the provider
+# ARN-validates, so it needs a syntactically valid mocked ARN.
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+      arn        = "arn:aws:iam::123456789012:role/terraform"
+      id         = "123456789012"
+      user_id    = "AROAEXAMPLEID"
+    }
+  }
+}
 
 run "setup" {
   module {
@@ -15,6 +26,17 @@ run "default" {
 
   module {
     source = "./"
+  }
+
+  # aws_iam_policy_document is rendered by the AWS provider, so under mock_provider
+  # its `json` attribute is a generated value rather than the real policy. We can't
+  # assert on individual statements here; overriding it with a known value lets us
+  # assert the policy-selection logic (default_policy.enable + var.policy) instead.
+  override_data {
+    target = data.aws_iam_policy_document.kms_key_policy
+    values = {
+      json = "{\"Sid\":\"GeneratedDefault\"}"
+    }
   }
 
   variables {
@@ -46,5 +68,84 @@ run "default" {
   assert {
     condition     = aws_kms_key.default.is_enabled == true
     error_message = "Expected KMS key to be enabled, got: ${aws_kms_key.default.is_enabled}"
+  }
+
+  # KMS key policy: with no explicit policy and default_policy.enable defaulting to
+  # true, the generated default policy is applied to the key.
+  assert {
+    condition     = aws_kms_key.default.policy == "{\"Sid\":\"GeneratedDefault\"}"
+    error_message = "Expected the generated default policy to be applied, got: ${aws_kms_key.default.policy}"
+  }
+}
+
+# An explicit policy must take precedence over the generated default policy.
+run "explicit_policy_takes_precedence" {
+  command = plan
+
+  module {
+    source = "./"
+  }
+
+  override_data {
+    target = data.aws_iam_policy_document.kms_key_policy
+    values = {
+      json = "{\"Sid\":\"GeneratedDefault\"}"
+    }
+  }
+
+  variables {
+    name   = "explicit-${run.setup.random_string}"
+    policy = "{\"Sid\":\"Explicit\"}"
+  }
+
+  assert {
+    condition     = aws_kms_key.default.policy == "{\"Sid\":\"Explicit\"}"
+    error_message = "Expected the explicit policy to take precedence over the generated default, got: ${aws_kms_key.default.policy}"
+  }
+}
+
+# When default_policy.enable is false and no explicit policy is set, the key policy
+# is left unmanaged so AWS applies its built-in default key policy. The module
+# output reflects this as null.
+run "default_policy_disabled_is_unmanaged" {
+  command = plan
+
+  module {
+    source = "./"
+  }
+
+  variables {
+    name = "disabled-${run.setup.random_string}"
+    default_policy = {
+      enable = false
+    }
+  }
+
+  assert {
+    condition     = output.policy == null
+    error_message = "Expected output.policy to be null when default_policy.enable is false and no policy is set"
+  }
+}
+
+# When default_policy.enable is false but an explicit policy is supplied, that
+# policy is used verbatim and the generated default is not consulted.
+run "default_policy_disabled_with_explicit_policy" {
+  command = plan
+
+  module {
+    source = "./"
+  }
+
+  variables {
+    name   = "disabled-explicit-${run.setup.random_string}"
+    policy = "{\"Sid\":\"Explicit\"}"
+    default_policy = {
+      enable = false
+    }
+  }
+
+  assert {
+    condition     = output.policy == "{\"Sid\":\"Explicit\"}"
+    error_message = "Expected the explicit policy to be used when default_policy.enable is false, got: ${output.policy}"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -61,6 +61,24 @@ variable "policy" {
   description = "A valid KMS policy JSON document"
 }
 
+variable "default_policy" {
+  type = object({
+    enable                    = optional(bool, true)
+    override_policy_documents = optional(list(string), [])
+    source_policy_documents   = optional(list(string), [])
+
+    iam_all_principals_read  = optional(bool, true)
+    iam_arns_administrator   = optional(list(string), [])
+    iam_arns_decrypt         = optional(list(string), [])
+    iam_arns_decrypt_encrypt = optional(list(string), [])
+    iam_arns_owner           = optional(list(string), [])
+    iam_arns_sign_verify     = optional(list(string), [])
+    iam_aws_config_read      = optional(bool, true)
+  })
+  default     = {}
+  description = "Configuration object for defining the KMS key policy and permissions"
+}
+
 variable "region" {
   type        = string
   default     = null


### PR DESCRIPTION
## :hammer_and_wrench: Summary

By default the module now generates a least-privilege KMS key policy from a new `default_policy` object, instead of falling back to AWS's default key policy. Access (administration, encrypt/decrypt, sign/verify, owner) is granted by listing principal ARNs in `default_policy.iam_arns_*`. If no administrator is given, the calling identity is added so the key is never left unmanageable.