### PR TITLE
feat: add new variable to configure the path of the kms key alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ No modules.
 | <a name="input_enable_key_rotation"></a> [enable\_key\_rotation](#input\_enable\_key\_rotation) | Specifies whether key rotation is enabled | `bool` | `true` | no |
 | <a name="input_key_usage"></a> [key\_usage](#input\_key\_usage) | Specifies the intended use of the key. | `string` | `"ENCRYPT_DECRYPT"` | no |
 | <a name="input_multi_region"></a> [multi\_region](#input\_multi\_region) | Indicates whether the KMS key is a multi-Region (`true`) or regional (`false`) key. | `bool` | `false` | no |
+| <a name="input_path"></a> [path](#input\_path) | Path of the KMS key alias | `string` | `"/"` | no |
 | <a name="input_policy"></a> [policy](#input\_policy) | A valid KMS policy JSON document | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | The AWS region where resources will be created; if omitted the default provider region is used | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the key | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ data "aws_partition" "current" {}
 
 resource "aws_kms_alias" "default" {
   region        = var.region
-  name          = "alias/${var.name}"
+  name          = "alias${var.path}${var.name}"
   target_key_id = aws_kms_key.default.key_id
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,17 @@ variable "name" {
   description = "The name of the key"
 }
 
+variable "path" {
+  type        = string
+  default     = "/"
+  description = "Path of the KMS key alias"
+
+  validation {
+    condition     = length(regex("^(\\/|\\/.+\\/)$", var.path)) > 0
+    error_message = "The path must be '/' or start and end with '/' (e.g., '/custom/')."
+  }
+}
+
 variable "policy" {
   type        = string
   default     = null


### PR DESCRIPTION
## :hammer_and_wrench: Summary

- add `var.path`: Path of the KMS key alias 
